### PR TITLE
turned staking on wallet page into a two step process

### DIFF
--- a/src/components/pillButton/pillButton.tsx
+++ b/src/components/pillButton/pillButton.tsx
@@ -7,6 +7,7 @@ export interface Props {
   color: string;
   label: string;
   clickFunction: any;
+  iconColor?: string;
   small?: boolean;
   disabled?: boolean;
   pending?: boolean;

--- a/src/components/pillButton/pillButtonStyles.ts
+++ b/src/components/pillButton/pillButtonStyles.ts
@@ -28,9 +28,10 @@ const useStyles = makeStyles(() =>
 
     },
     icon: {
-      color: "inherit",
-      margin: "auto auto auto 1rem",
-      width: "2rem",
+      color: (style: Theme & Props) =>
+        style.iconColor ? style.iconColor : "inherit",
+      marginLeft: "5px",
+      width: "20px",
     },
     rotate: {
       animation: `rotate 1s infinite`,

--- a/src/components/stakeToken/stakeToken.tsx
+++ b/src/components/stakeToken/stakeToken.tsx
@@ -131,23 +131,50 @@ function StakeToken(props: any) {
         ) : (
           <>
             {!state.flags.approvedTokens ? (
-              <div className={classes.buttonContainer}>
-                <PillButton
-                  color="green"
-                  label="Approve tokens"
-                  pending={state.flags.approvedTokensPending}
-                  clickFunction={() => approveTokens()}
-                />
-              </div>
+              <>
+                <div className={classes.buttonContainer}>
+                  <PillButton
+                    color="green"
+                    label="Approve tokens"
+                    pending={state.flags.approvedTokensPending}
+                    clickFunction={() => approveTokens()}
+                  />
+                </div>
+                <div className={classes.buttonContainer}>
+                  <PillButton
+                    color="grey"
+                    label="Stake tokens"
+                    clickFunction={lockTokens}
+                    disabled={true}
+                    pending={false}
+                    success={false}
+                    fail={false}
+                  />
+                </div>
+              </>
             ) : (
-              <div className={classes.buttonContainer}>
-                <PillButton
-                  color="green"
-                  label="Stake tokens"
-                  clickFunction={() => lockTokens()}
-                  pending={state.flags.stakeTokensPending}
-                />
-              </div>
+              <>
+                <div className={classes.buttonContainer}>
+                  <PillButton
+                    color="grey"
+                    label="Approve tokens"
+                    clickFunction={lockTokens}
+                    iconColor="green"
+                    disabled={true}
+                    pending={false}
+                    success={true}
+                    fail={false}
+                  />
+                </div>
+                <div className={classes.buttonContainer}>
+                  <PillButton
+                    color="green"
+                    label="Stake tokens"
+                    clickFunction={() => lockTokens()}
+                    pending={state.flags.stakeTokensPending}
+                  />
+                </div>
+              </>
             )}
           </>
         )}


### PR DESCRIPTION
Closes #9 

turned staking on wallet page into a two step process:

<img width="1536" alt="Screenshot 2021-07-03 at 19 23 00" src="https://user-images.githubusercontent.com/26834619/124363782-953f4700-dc3d-11eb-84d5-e1897267ad5e.png">
<img width="1534" alt="Screenshot 2021-07-03 at 19 23 34" src="https://user-images.githubusercontent.com/26834619/124363784-98d2ce00-dc3d-11eb-82c0-bec18b98d1c5.png">
