### PR TITLE
49 staking loading spinners

### DIFF
--- a/src/components/stakeToken/stakeToken.tsx
+++ b/src/components/stakeToken/stakeToken.tsx
@@ -176,7 +176,7 @@ function StakeToken(props: any) {
                   <PillButton
                     color="grey"
                     label="Withdraw tokens"
-                    pending={false}
+                    pending={state.flags.withdrawTokensPending}
                     clickFunction={() => withdrawTokens()}
                   />
                 </div>
@@ -209,7 +209,7 @@ function StakeToken(props: any) {
                     label="Withdraw tokens"
                     clickFunction={lockTokens}
                     disabled={true}
-                    pending={false}
+                    pending={state.flags.withdrawTokensPending}
                     fail={false}
                   />
                 </div>

--- a/src/components/stakeToken/stakeToken.tsx
+++ b/src/components/stakeToken/stakeToken.tsx
@@ -176,7 +176,7 @@ function StakeToken(props: any) {
                   <PillButton
                     color="grey"
                     label="Withdraw tokens"
-                    pending={state.flags.approvedTokensPending}
+                    pending={false}
                     clickFunction={() => withdrawTokens()}
                   />
                 </div>

--- a/src/store/middleware.ts
+++ b/src/store/middleware.ts
@@ -35,6 +35,9 @@ export const applyMiddleware = (dispatch) => (action) => {
         })
       );
     case types.Stake.STAKE_TOKENS_REQUEST:
+      dispatch({
+        type: types.Stake.STAKE_TOKENS_REQUEST
+      });
       return stake(action.payload)
         .then((res) => {
           dispatch({
@@ -63,6 +66,9 @@ export const applyMiddleware = (dispatch) => (action) => {
         })
       );
     case types.ApproveTokens.APPROVE_TOKENS_REQUEST:
+      dispatch({
+        type: types.ApproveTokens.APPROVE_TOKENS_REQUEST
+      });
       return approveTokens(action.payload)
       .then((res) => {
         dispatch({

--- a/src/store/middleware.ts
+++ b/src/store/middleware.ts
@@ -52,6 +52,9 @@ export const applyMiddleware = (dispatch) => (action) => {
           })
         );
     case types.Withdraw.WITHDRAW_TOKEN_REQUEST:
+      dispatch({
+        type: types.Withdraw.WITHDRAW_TOKEN_REQUEST
+      });
       return withdraw(action.payload)
       .then((res) => {
         dispatch({

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -36,6 +36,8 @@ export interface IFlags {
   approvedTokensPending: boolean;
   stakeTokensPending: boolean;
   stakedTokens: boolean;
+  withdrawTokensPending: boolean;
+  withdrawedTokens:boolean;
   loadingProposalNumbers:boolean;
   proposalCreated: boolean;
   creatingProposal: boolean;
@@ -110,6 +112,8 @@ const initialFlags: IFlags = {
   approvedTokensPending: false,
   stakedTokens: false,
   stakeTokensPending: false,
+  withdrawedTokens: false,
+  withdrawTokensPending: false,
   loadingProposalNumbers: false,
   proposalCreated: false,
   creatingProposal: false
@@ -189,7 +193,13 @@ const reducer = (state = initialState, action) => {
     case types.Stake.STAKE_TOKENS_SUCCESS:
       return { ...state, flags: {...state.flags,approvedTokens:false, stakedTokens:true, stakeTokensPending:false}};
     case types.Stake.STAKE_TOKENS_FAIL:
-        return { ...state, flags: {...state.flags, stakedTokens:false, stakeTokensPending:false}};
+      return { ...state, flags: {...state.flags, stakedTokens:false, stakeTokensPending:false}};
+    case types.Withdraw.WITHDRAW_TOKEN_REQUEST:
+      return { ...state, flags: {...state.flags,withdrawTokensPending:true}};
+    case types.Withdraw.WITHDRAW_TOKEN_SUCCESS:
+      return { ...state, flags: {...state.flags, withdrawedTokens:true, withdrawTokensPending:false}};
+    case types.Withdraw.WITHDRAW_TOKEN_FAIL:
+      return { ...state, flags: {...state.flags, withdrawedTokens:false, withdrawTokensPending:false}}
     case types.ApproveTokens.APPROVE_TOKENS_FAIL:
       return { ...state, flags: {...state.flags, approvedTokens:false
       },error: action.payload,};

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -180,6 +180,8 @@ const reducer = (state = initialState, action) => {
       return { ...state, error: action.payload, loading: false };
     case types.SetBalances.SET_BALANCES_SUCCESS:
       return { ...state, balances: action.payload, loading: false };
+    case types.ApproveTokens.APPROVE_TOKENS_REQUEST:
+      return { ...state, flags: {...state.flags, approvedTokensPending:true}};
     case types.ApproveTokens.APPROVE_TOKENS_SUCCESS:
       return { ...state, flags: {...state.flags, approvedTokens:true, stakedTokens:false, approvedTokensPending:false}};
     case types.Stake.STAKE_TOKENS_REQUEST:


### PR DESCRIPTION
Implements a loading spinner for the approving + staking process

This is a quick fix for the issue #49, but doesn’t solve the issue that it is slow + any of the connection issues when reloading the page