### PR TITLE
Discourse discussion button

### DIFF
--- a/src/components/ProposalsList.vue
+++ b/src/components/ProposalsList.vue
@@ -126,6 +126,11 @@
           <!-- dummy to align vote display to box bottom -->
           <div class="flex-grow mb-5" />
           <votes-info :proposal="proposal" />
+          <form :action="proposal.proposalContent.link" target="_blank">
+            <button class="text-sm mt-4 border p-3 rounded-lg" type="submit">
+              Discourse Discussion
+            </button>
+          </form>
         </dl>
       </div>
       <div>

--- a/src/pages/ProposalsPage.vue
+++ b/src/pages/ProposalsPage.vue
@@ -34,6 +34,7 @@ export const proposalFragment = gql`
     minVotesNeeded
     proposalContent {
       title
+      link
       type
     }
   }


### PR DESCRIPTION
This PR is addressing this issue: https://github.com/VitaDAO/VitaDAO-web3/issues/23

Wrapping <a hrefs /> over buttons don't work and is considered not the best practice; hence using the <form><button /> </form> approach.

Below is a screenshot:
<img width="1298" alt="Screen Shot 2021-10-26 at 2 08 50 PM" src="https://user-images.githubusercontent.com/25126146/138972888-c1514cab-6f9b-4473-8967-ff6be7447a53.png">

